### PR TITLE
Introduce multi-layered canvas rendering for optimization

### DIFF
--- a/components/game/block.js
+++ b/components/game/block.js
@@ -97,6 +97,14 @@ function getPrevRotateDirection(currentRotateDirection, rotationAmount) {
   }
 }
 
+function markDiffToPrev(cur, prev) {
+  for (let x = 0; x < widthBlockCount + outBorderBlockCount * 2; x++) {
+    for (let y = 0; y < heightBlockCount + outBorderBlockCount; y++) {
+      cur[x][y].isPrevExisted = prev[x][y].isExist != cur[x][y].isExist
+    }
+  }
+}
+
 class ControlBlock {
   constructor() {
     this.currentRotateDirection = 0;
@@ -328,6 +336,7 @@ class ControlBlock {
       }
     }
 
+    markDiffToPrev(rotatedBlockArray, controlBlock.blockArray)
     this.currentRotateDirection = newRotateDirection;
     controlBlock.blockArray = rotatedBlockArray;
 
@@ -457,6 +466,7 @@ function initBlockArray(blockArray) {
     for (let y = 0; y < heightBlockCount + outBorderBlockCount; y++) {
       blockArray[x][y] = {
         isExist: false,
+        isPrevExisted: false,
       };
     }
   }
@@ -467,7 +477,7 @@ function initBlockArray(blockArray) {
 function moveToBottomOneLine(blockArray) {
   for (let x = 0; x < widthBlockCount + outBorderBlockCount * 2; x++) {
     for (let y = heightBlockCount + outBorderBlockCount - 1; y != 0; y--) {
-      copySingleBlock(blockArray[x][y], blockArray[x][y - 1]);
+      copySingleBlockWithPrev(blockArray[x][y], blockArray[x][y - 1], blockArray[x][y].isExist); 
     }
     blockArray[x][0].isExist = false;
   }
@@ -476,7 +486,7 @@ function moveToBottomOneLine(blockArray) {
 function moveToLeftOneLine(blockArray) {
   for (let y = 0; y < heightBlockCount + outBorderBlockCount; y++) {
     for (let x = 0; x < widthBlockCount + outBorderBlockCount * 2 - 1; x++) {
-      copySingleBlock(blockArray[x][y], blockArray[x + 1][y]);
+      copySingleBlockWithPrev(blockArray[x][y], blockArray[x + 1][y], blockArray[x][y].isExist);
     }
     blockArray[widthBlockCount + outBorderBlockCount * 2 - 1][
       y
@@ -487,7 +497,7 @@ function moveToLeftOneLine(blockArray) {
 function moveToRightOneLine(blockArray) {
   for (let y = 0; y < heightBlockCount + outBorderBlockCount; y++) {
     for (let x = widthBlockCount + outBorderBlockCount * 2 - 1; x != 0; x--) {
-      copySingleBlock(blockArray[x][y], blockArray[x - 1][y]);
+      copySingleBlockWithPrev(blockArray[x][y], blockArray[x - 1][y], blockArray[x][y].isExist);
     }
     blockArray[0][y].isExist = false;
   }
@@ -602,6 +612,8 @@ function isBlockReachedToRightBorder(blockArray) {
 function clearBlockArray(blockArray) {
   for (let x = 0; x < widthBlockCount + outBorderBlockCount * 2; x++) {
     for (let y = 0; y < heightBlockCount + outBorderBlockCount; y++) {
+      if(blockArray[x][y].isExist)
+        blockArray[x][y].isPrevExisted = true
       blockArray[x][y].isExist = false;
       blockArray[x][y].blockColor = null;
     }
@@ -617,6 +629,11 @@ function copyBlockArray(blockArray) {
     }
   }
   return tmpArray;
+}
+
+function copySingleBlockWithPrev(blockTo, blockFrom, prev) {
+  blockTo.isPrevExisted = prev
+  copySingleBlock(blockTo, blockFrom)
 }
 
 function copySingleBlock(blockTo, blockFrom) {

--- a/css/screen.css
+++ b/css/screen.css
@@ -12,8 +12,24 @@ body {
 canvas {
   width: 500;
   height: 680px;
+  left:0;
+  top:0;
+}
+#stage {
+  width:500px;
+  height:680px;
+  position:relative;
 }
 
+#canvas {
+  position: absolute;
+  z-index: 1;
+}
+
+#background {
+  z-index: 0;
+  position: absolute;
+}
 h1 {
   margin-bottom: -20px;
 }

--- a/index.html
+++ b/index.html
@@ -34,7 +34,10 @@
       <h5 id="game-over">GAME OVER</h5>
       <div class="screen">
         <img id="youngImg" src="res/young.png"/>
-        <canvas id="canvas" width="500" height="680"></canvas>
+        <div id="stage">
+            <canvas id="canvas" width="500" height="680"></canvas>
+            <canvas id="background" width="500" height="680"></canvas>
+        </div>
         <img id="chanImg" src="res/chan.png"/>
       </div>
     </div>


### PR DESCRIPTION
Previously, The all blocks are rendered every events or updates.
It could possibly cause performance issue.
Please see [1]. The keyboard event spends 20ms so the rendering update is delayed which over 16ms for 60 FPS.
It may cause a bad-user experience.

Therefore, Separate rendering layers to reduce rendering time.
The background tiles are rendered only once when the canvas is initialized.
Also, Stacked blocks are not required to render  every time. So add "shouldUpdateStackedLayer" to use checking update the stacked block.

So, update blocks are only control-blocks.

Note here [2], the rendering time is reduced to 13~6ms.

Also, this CL contains minor refactoring for draw-rects

[1] https://user-images.githubusercontent.com/18409763/110893398-40e42480-8339-11eb-928e-fb41a4ca7020.png

[2] https://user-images.githubusercontent.com/18409763/110893887-34140080-833a-11eb-878f-7156b6fb81e7.png