### PR TITLE
redraw() must be called when a shift event called

### DIFF
--- a/components/game/block.js
+++ b/components/game/block.js
@@ -97,6 +97,14 @@ function getPrevRotateDirection(currentRotateDirection, rotationAmount) {
   }
 }
 
+function captureCurrentRenderToArray(blockArray, target) {
+  for (let x = 0; x < widthBlockCount + outBorderBlockCount * 2; x++) {
+    for (let y = 0; y < heightBlockCount + outBorderBlockCount; y++) {
+        target[x][y].isExist =  blockArray[x][y].isExist
+    }
+  }
+}
+
 function markDiffToPrev(cur, prev) {
   for (let x = 0; x < widthBlockCount + outBorderBlockCount * 2; x++) {
     for (let y = 0; y < heightBlockCount + outBorderBlockCount; y++) {
@@ -110,9 +118,11 @@ class ControlBlock {
     this.currentRotateDirection = 0;
     this.initBlockTypes();
     this.initPreviewBlocks();
+    this.prevBlockArray = new Array(widthBlockCount + outBorderBlockCount * 2)
     this.blockArray = new Array(widthBlockCount + outBorderBlockCount * 2);
     this.controlBlockCount = 0;
     initBlockArray(this.blockArray);
+    initBlockArray(this.prevBlockArray);
     this.initControlBlockType();
   }
 
@@ -173,9 +183,9 @@ class ControlBlock {
   }
 
   refreshBlockArray() {
+    captureCurrentRenderToArray(this.blockArray, this.prevBlockArray)
     this.currentRotateDirection = 0;
     clearBlockArray(this.blockArray);
-
     let shape = this.controlBlockType.blockType.shape;
     for (let i = 0; i < shape.length; i++) {
       let block = this.blockArray[
@@ -184,6 +194,7 @@ class ControlBlock {
       block.isExist = true;
       block.blockColor = this.controlBlockType.blockType.blockColor;
     }
+    markDiffToPrev(this.blockArray, this.prevBlockArray)
   }
 
   rotate(
@@ -261,6 +272,7 @@ class ControlBlock {
     moveRightCount,
     moveBottomCount
   ) {
+    captureCurrentRenderToArray(this.blockArray, this.prevBlockArray)
     if (
       !isInBorder(rotatedBlockArray) ||
       isOverlaped(rotatedBlockArray, stackedBlockArray)
@@ -336,7 +348,7 @@ class ControlBlock {
       }
     }
 
-    markDiffToPrev(rotatedBlockArray, controlBlock.blockArray)
+    markDiffToPrev(rotatedBlockArray, this.prevBlockArray)
     this.currentRotateDirection = newRotateDirection;
     controlBlock.blockArray = rotatedBlockArray;
 

--- a/components/game/screen.js
+++ b/components/game/screen.js
@@ -341,7 +341,7 @@ class GameScreen {
       this.shiftBlock.setShiftBlock(this.controlBlock.controlBlockType);
       this.changeControlBlock(tmpBlockType);
     }
-
+    this.reDraw()
     this.flowGravity();
   }
 


### PR DESCRIPTION
It might be related to this [1] patch.

This commit is related in [2].

When the shift key is pressed, the current control block is marked as 'isPrevExisted' which means the blocks must be cleared.

Therefore, insert 'redraw()' function in shiftControlBlock() to clear previous blocks and rendering current control-block.

Also, added 'captureCurrentRenderToArray()' function and prevBlockArray to capture current block rendering status for checking difference with 'markDiffToPrev()'

For example case in ControlBlock class:

captureCurrentRenderToArray(this.blockArray, this.prevBlockArray)

/* some blockArray change code */

markDiffToPrev(this.blockArray, this.prevBlockArray)

[1] https://github.com/WoochanLee/BalanceTetris/pull/9/commits/004b49d3b2a76e17c2d120a626be0e2d9df553ff
[2] https://github.com/WoochanLee/BalanceTetris/issues/12